### PR TITLE
Fix Redundancy Check

### DIFF
--- a/src/jquery.ns-autogrow.coffee
+++ b/src/jquery.ns-autogrow.coffee
@@ -18,8 +18,8 @@
 
       $e = $(@)
 
-      return if $e.data 'autogrow-enabled'
-      $e.data 'autogrow-enabled'
+      return if $e.data 'autogrow-enabled' == 'true'
+      $e.data 'autogrow-enabled', true
 
       minHeight     = $e.height()
       minWidth      = $e.width()


### PR DESCRIPTION
I noticed the redundancy check on line 21 wasn't actually returning on a textarea where I called .autogrow more than once. Apparently doing $e.data('autogrow-enabled') doesn't add anything to $e's data, because $e.data() was {} after it. Specifying a value and checking for it seemed to do the trick. Thanks for the plugin, it is fantastic!
