### PR TITLE
fix redundancy check

### DIFF
--- a/src/jquery.ns-autogrow.coffee
+++ b/src/jquery.ns-autogrow.coffee
@@ -18,7 +18,7 @@
 
       $e = $(@)
 
-      return if $e.data 'autogrow-enabled' == 'true'
+      return if $e.data 'autogrow-enabled' == true
       $e.data 'autogrow-enabled', true
 
       minHeight     = $e.height()


### PR DESCRIPTION
I goofed with the last pull request. I had the if statement checking for the string 'true' yet I was assigning the boolean value true, which of course causes the if statement to always be false. This fix makes the if statement check for the boolean true instead of the string 'true'. Sorry about that!
